### PR TITLE
Fix whois_request socket not closed

### DIFF
--- a/pythonwhois/net.py
+++ b/pythonwhois/net.py
@@ -82,13 +82,13 @@ def get_root_server(domain):
 	raise shared.WhoisException("No root WHOIS server found for domain.")
 	
 def whois_request(domain, server, port=43):
-	sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	sock.connect((server, port))
-	sock.send(("%s\r\n" % domain).encode("utf-8"))
-	buff = b""
-	while True:
-		data = sock.recv(1024)
-		if len(data) == 0:
-			break
-		buff += data
-	return buff.decode("utf-8")
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+		sock.connect((server, port))
+		sock.send(("%s\r\n" % domain).encode("utf-8"))
+		buff = b""
+		while True:
+			data = sock.recv(1024)
+			if len(data) == 0:
+				break
+			buff += data
+		return buff.decode("utf-8")


### PR DESCRIPTION
Fix the ResourceWarning socket unclosed 
```
lib/python3.9/site-packages/pythonwhois/net.py:76: ResourceWarning: unclosed <socket.socket fd=15, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('192.168.1.87', 55020), raddr=('192.0.32.59', 43)>
    data = whois_request(domain, "whois.iana.org")
```