### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setuptools.setup(
     packages=['pythonwhois'],
     package_dir={"pythonwhois":"pythonwhois"},
     package_data={"pythonwhois":["*.dat"]},
-    install_requires=['argparse'],
     provides=['pythonwhois'],
     scripts=["pwhois"],
 


### PR DESCRIPTION
argparse is in the standard library on every Python version this library supports, so it doesn't need to be declared as a dependency.